### PR TITLE
Update Regex for newer iCUE5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="HeadsetName" value="Headphones"/> //Use your headphone's name
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 		<add key="Autorun" value="true"/>
-		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
-		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
+		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"(?:\w|\s|\d)+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
+		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"(?:\w|\s|\d)+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
 	</appSettings>
 </configuration>
 ```

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="HeadsetName" value="Headphones"/> //Use your headphone's name
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 		<add key="Autorun" value="true"/>
-		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"(?:\w|\s|\d)+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
-		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"(?:\w|\s|\d)+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
+		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s"(?:\w|\s|\d)+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
+		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s"(?:\w|\s|\d)+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
 	</appSettings>
 </configuration>
+
 ```
 
 ## iCUE 4
@@ -40,4 +41,5 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the desired device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 	</appSettings>
 </configuration>
+
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="HeadsetName" value="Headphones"/> //Use your headphone's name
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 		<add key="Autorun" value="true"/>
-		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s"(?:\w|\s|\d)+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
-		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s"(?:\w|\s|\d)+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
+		<add key="ConnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s.?(?:\w|\s|\d)+.?\sDisconnected\s->\s(?:Wireless)|(?:Direct)"/> //this is a "device connected" regex override for iCUE5
+		<add key="DisconnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_(?:controller)|(?:proxy):\s.?(?:\w|\s|\d)+.?\s(?:Wireless)|(?:Direct)\s->\sDisconnected"/> //this is a "device disconnected" regex override for iCUE5
 	</appSettings>
 </configuration>
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="HeadsetName" value="Headphones"/> //Use your headphone's name
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 		<add key="Autorun" value="true"/>
-		<add key="ConnectedRegexOverride" value="\d{4}\-\d\d\-\d\d\s(?:\d\d\:)*\d\d.\d+ I cue\.dev\.connection_proxy: .?(\w*).? Disconnected -> (?:Wireless|Direct)"/> //this is a "device connected" regex override for iCUE 5
-		<add key="DisconnectedRegexOverride" value="\d{4}\-\d\d\-\d\d\s(?:\d\d\:)*\d\d.\d+ I cue\.dev\.connection_proxy: .?(\w*).? (?:Wireless|Direct) -> Disconnected"/> //this is a "device disconnected" regex override for iCUE 5
+		<add key="ConnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)"/> //this is a "device connected" regex override for iCUE5
+		<add key="DisconnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected"/> //this is a "device disconnected" regex override for iCUE5
 	</appSettings>
 </configuration>
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Disclaimer - this software has no association to `Corsair Gaming, Inc` , is prov
 		<add key="HeadsetName" value="Headphones"/> //Use your headphone's name
 		<add key="SpeakersName" value="Speakers"/> //if you have more than one device named "Speakers"(for example if you use steam remote play you might heve a device named "Steam Streaming Speakers", which will too show up in the command output), then use the full name of the device as reported by get-audiodevice -list | where Type -eq 'Playback' in powershell
 		<add key="Autorun" value="true"/>
-		<add key="ConnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)"/> //this is a "device connected" regex override for iCUE5
-		<add key="DisconnectedRegexOverride" value="\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected"/> //this is a "device disconnected" regex override for iCUE5
+		<add key="ConnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\sDisconnected\s->\s(?:Wireless)|(?:Direct)'/> //this is a "device connected" regex override for iCUE5
+		<add key="DisconnectedRegexOverride" value='\d{4}-\d\d-\d\d\s(?:\d\d:?)+\.\d+\sI\scue\.dev\.connection_controller:\s"\w+"\s(?:Wireless)|(?:Direct)\s->\sDisconnected'/> //this is a "device disconnected" regex override for iCUE5
 	</appSettings>
 </configuration>
 ```


### PR DESCRIPTION
This is an overall overhaul of the regex to make HeadsetUtils work with latest version of iCUE5 and, perhaps, older ones as well
(Workflow update(#12) is excluded from this PR)